### PR TITLE
fix: メールアドレスを環境変数に変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,8 +69,8 @@ Rails.application.configure do
     address: "smtp.gmail.com",
     port: 587,
     domain: "gmail.com",
-    user_name: "beppu.app@gmail.com",
-    password: "#{ENV['GMAIL_PASS']}",
+    user_name: ENV['GMAIL_ADDRESS'],
+    password: ENV['GMAIL_PASS'],
     authentication: :plain,
     enable_starttls_auto: true
   }


### PR DESCRIPTION
環境変数にすることで本番環境でもメール送信ができたとの記事
https://qiita.com/kobayashimakoto/items/c7a96ea9f6cbc8d2da77